### PR TITLE
Fix Counter Colors groupBox bottom clipping

### DIFF
--- a/src/LiveSplit.Counter/UI/Components/CounterComponentSettings.Designer.cs
+++ b/src/LiveSplit.Counter/UI/Components/CounterComponentSettings.Designer.cs
@@ -86,9 +86,9 @@
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 112F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 115F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 100F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(442, 448);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(442, 451);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // groupBox2
@@ -98,7 +98,7 @@
             this.groupBox2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupBox2.Location = new System.Drawing.Point(3, 32);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(436, 106);
+            this.groupBox2.Size = new System.Drawing.Size(436, 109);
             this.groupBox2.TabIndex = 4;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Counter Colors";
@@ -120,7 +120,7 @@
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 29F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(430, 87);
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(430, 90);
             this.tableLayoutPanel3.TabIndex = 0;
             // 
             // chkColor
@@ -235,7 +235,7 @@
             this.tableLayoutPanel1.SetColumnSpan(this.groupBox4, 4);
             this.groupBox4.Controls.Add(this.tableLayoutPanel5);
             this.groupBox4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox4.Location = new System.Drawing.Point(3, 144);
+            this.groupBox4.Location = new System.Drawing.Point(3, 147);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Size = new System.Drawing.Size(436, 301);
             this.groupBox4.TabIndex = 42;
@@ -458,7 +458,7 @@
             this.Controls.Add(this.tableLayoutPanel1);
             this.Name = "CounterComponentSettings";
             this.Padding = new System.Windows.Forms.Padding(7);
-            this.Size = new System.Drawing.Size(456, 462);
+            this.Size = new System.Drawing.Size(456, 465);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.groupBox2.ResumeLayout(false);


### PR DESCRIPTION
## Problem

The "Counter Colors" `groupBox2` parent row was `Absolute 112F`. After the GroupBox title overhead (~19F) and 6F margins, the inner `tableLayoutPanel3` got 87F of client area, exactly matching its inner rows (29F × 3 = 87F). Zero slack caused 1F clipping at the bottom of the last row (Value Color button) due to WinForms layout rounding.

The clipping was pre-existing in the design but became visually obvious only after the font override commit (f310edb) removed the Font row above and shrank the form, removing the visual buffer around the Color groupBox.

## Changes

- Bump the "Counter Colors" row from `Absolute 112F` → `Absolute 115F` (+3F internal slack)
- Shift `groupBox4` `Location` by +3F to keep the layout flow correct
- Grow form size from `(456, 462)` → `(456, 465)` to accommodate the extra 3F

## Verification

- `dotnet build` clean (0 warnings, 0 errors)
- The Value Color picker button is no longer clipped at the bottom of the groupBox
